### PR TITLE
fix: Fixed running `roller config init` when root dir does not exist

### DIFF
--- a/cmd/config/init/prompt_existing_root.go
+++ b/cmd/config/init/prompt_existing_root.go
@@ -10,13 +10,20 @@ import (
 
 func dirNotEmpty(path string) (bool, error) {
 	info, err := os.Stat(path)
-	if err != nil || !info.IsDir() {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 		return false, err
 	}
+
+	if !info.IsDir() {
+		return false, fmt.Errorf("%s is not a directory", path)
+	}
+
 	files, err := ioutil.ReadDir(path)
 	return len(files) > 0, err
 }
-
 func promptOverwriteConfig(home string) (bool, error) {
 	prompt := promptui.Prompt{
 		Label:     fmt.Sprintf("Directory %s is not empty. Do you want to overwrite", home),

--- a/test/config/init/init_test.go
+++ b/test/config/init/init_test.go
@@ -2,6 +2,7 @@ package initconfig_test
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"os"
@@ -35,6 +36,7 @@ func TestInitCmd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 			tempDir, err := ioutil.TempDir(os.TempDir(), "test")
+			tempDir = filepath.Join(tempDir, ".roller")
 			assert.NoError(err)
 			defer func() {
 				err := os.RemoveAll(tempDir)


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
