### PR TITLE
fix: setting keyring-backend os for the client

### DIFF
--- a/cmd/config/init/genesis.go
+++ b/cmd/config/init/genesis.go
@@ -38,7 +38,7 @@ func initializeRollappGenesis(initConfig config.RollappConfig) error {
 		return err
 	}
 	genesisRelayerAccountCmd := exec.Command(initConfig.RollappBinary, "add-genesis-account",
-		rlyRollappAddress, relayerBalanceStr, "--home", rollappConfigDirPath)
+		rlyRollappAddress, relayerBalanceStr, "--keyring-backend", "test", "--home", rollappConfigDirPath)
 	_, err = utils.ExecBashCommand(genesisRelayerAccountCmd)
 	if err != nil {
 		return err

--- a/cmd/config/init/rollapp.go
+++ b/cmd/config/init/rollapp.go
@@ -22,6 +22,7 @@ func initializeRollappConfig(initConfig config.RollappConfig) error {
 		return err
 	}
 
+	//TODO: This should be removed once https://github.com/dymensionxyz/dymension-rdk/issues/238 is fixed
 	setConfigCmd := exec.Command(initConfig.RollappBinary, "config", "keyring-backend", "test", "--home", home)
 	_, err = utils.ExecBashCommand(setConfigCmd)
 	if err != nil {
@@ -42,6 +43,12 @@ func initializeRollappConfig(initConfig config.RollappConfig) error {
 
 	err = setRollappAppConfig(filepath.Join(initConfig.Home, consts.ConfigDirName.Rollapp, "config/app.toml"),
 		initConfig.Denom)
+	if err != nil {
+		return err
+	}
+
+	setConfigCmd = exec.Command(initConfig.RollappBinary, "config", "keyring-backend", "os", "--home", home)
+	_, err = utils.ExecBashCommand(setConfigCmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

The rollapp genesis account is created in the `keyring-backend test`
But the default client setting is left intact (`os` by default)

It fixes the funds drainage possible through the RPC as discussed on #281 


---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
