### PR TITLE
chore: Make e2e flow run only on a manual trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,5 @@
 name: Run E2E tests
 on:
-  release:
-    types: [ created ]
   workflow_dispatch:
 jobs:
   end_to_end_test:
@@ -63,7 +61,7 @@ jobs:
       - name: Execute IBC relay tester
         run: |
           chmod +x ./scripts/ibc_relay_tester.sh
-          DEST_ADDR=$HUB_SEQ_ADDR ROLLAPP_ID=$ROLLAPP_ID ROLLER_CONFIG_PATH=$ROLLER_CONFIG_PATH ./scripts/ibc_relay_tester.sh
+          DEST_ADDR=$HUB_SEQ_ADDR ROLLAPP_ID=$ROLLAPP_ID ROLLER_CONFIG_PATH=$ROLLER_CONFIG_PATH ./scripts/ibc_relay_tester.sh 2> script_errors.log
 
       - name: Terminate the rollapp
         if: always()


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
