### PR TITLE
fix: Prevent generate new avail seed in `roller migrate`

### DIFF
--- a/cmd/migrate/v_0_1_12.go
+++ b/cmd/migrate/v_0_1_12.go
@@ -21,6 +21,12 @@ func (v *VersionMigratorV0112) PerformMigration(rlpCfg config.RollappConfig) err
 		rlpCfg.DA = config.Local
 		return config.WriteConfigToTOML(rlpCfg)
 	}
+	if rlpCfg.DA == config.Avail {
+		availNewCfgPath := avail.GetCfgFilePath(rlpCfg.Home)
+		if err := utils.MoveFile(filepath.Join(rlpCfg.Home, avail.ConfigFileName), availNewCfgPath); err != nil {
+			return err
+		}
+	}
 	da := datalayer.NewDAManager(rlpCfg.DA, rlpCfg.Home)
 	sequencerDaConfig := da.GetSequencerDAConfig()
 	if sequencerDaConfig == "" {
@@ -28,12 +34,6 @@ func (v *VersionMigratorV0112) PerformMigration(rlpCfg config.RollappConfig) err
 	}
 	if err := utils.UpdateFieldInToml(dymintTomlPath, "da_config", sequencerDaConfig); err != nil {
 		return err
-	}
-	if rlpCfg.DA == config.Avail {
-		availNewCfgPath := avail.GetCfgFilePath(rlpCfg.Home)
-		if err := utils.MoveFile(filepath.Join(rlpCfg.Home, avail.ConfigFileName), availNewCfgPath); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
When updating the DA config in the v0.1.12 migrate, we first created a newAvail and then moved the avail config file to the new location. This caused generating a new avail seed and saving it only in the dymint.toml config. 

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
