### PR TITLE
Chore: Ensure the Release Workflow Does Not Break the CI Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,9 @@ jobs:
           mkdir roller_bins
           mkdir roller_bins/lib
           sudo cp ./celestia-node/cel-key ./roller_bins/lib/cel-key
+          sudo cp ./celestia-node/cel-key /usr/local/bin/roller_bins/cel-key
           sudo cp ./celestia-node/build/celestia ./roller_bins/lib/celestia
+          sudo cp ./celestia-node/build/celestia /usr/local/bin/roller_bins/celestia
           sudo cp ./cosmos-sdk/build/simd ./roller_bins/lib/simd
           sudo cp -r /usr/local/bin/roller_bins/* ./roller_bins/lib/
           sudo cp /usr/local/bin/roller ./roller_bins/roller


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
