### PR TITLE
fix: ibc clients creation stuck 

### DIFF
--- a/cmd/config/init/consts.go
+++ b/cmd/config/init/consts.go
@@ -39,10 +39,10 @@ var Hubs = map[string]config.HubData{
 		GAS_PRICE:       "0.25",
 	},
 	FroopylandHubName: {
-		API_URL:         "https://froopyland.api.silknodes.io:443",
+		API_URL:         "https://froopyland.blockpi.network:443/lcd/v1/public",
 		ID:              "froopyland_100-1",
-		RPC_URL:         "https://froopyland.rpc.silknodes.io:443",
-		ARCHIVE_RPC_URL: "https://froopy-archive.rpc.silknodes.io:443",
+		RPC_URL:         "https://froopyland.blockpi.network:443/rpc/v1/public",
+		ARCHIVE_RPC_URL: "https://froopyland.blockpi.network:443/rpc/v1/public",
 		GAS_PRICE:       "0.25",
 	},
 	LocalHubName: {

--- a/cmd/consts/consts.go
+++ b/cmd/consts/consts.go
@@ -85,10 +85,10 @@ var SpinnerMsgs = struct {
 }
 
 var FroopylandHubData = config.HubData{
-	API_URL:         "https://froopyland.api.silknodes.io:443",
+	API_URL:         "https://froopyland.blockpi.network:443/lcd/v1/public",
 	ID:              FroopylandHubID,
-	RPC_URL:         "https://froopyland.rpc.silknodes.io:443",
-	ARCHIVE_RPC_URL: "https://froopy-archive.rpc.silknodes.io:443",
+	RPC_URL:         "https://froopyland.blockpi.network:443/rpc/v1/public",
+	ARCHIVE_RPC_URL: "https://froopyland.blockpi.network:443/rpc/v1/public",
 	GAS_PRICE:       "0.25",
 }
 

--- a/relayer/clients.go
+++ b/relayer/clients.go
@@ -1,0 +1,32 @@
+package relayer
+
+import (
+	"github.com/dymensionxyz/roller/cmd/consts"
+	roller_utils "github.com/dymensionxyz/roller/utils"
+)
+
+func (r *Relayer) CheckClientsExist() (bool, error) {
+	rlyCfg, err := ReadRlyConfig(r.Home)
+	if err != nil {
+		return false, err
+
+	}
+	clientIDRollapp_raw, err := roller_utils.GetNestedValue(rlyCfg, []string{"paths", consts.DefaultRelayerPath, "dst", "client-id"})
+	if err != nil {
+		return false, nil
+	}
+
+	clientIDHub_raw, err := roller_utils.GetNestedValue(rlyCfg, []string{"paths", consts.DefaultRelayerPath, "src", "client-id"})
+	if err != nil {
+		return false, nil
+	}
+
+	clientIDRollapp := clientIDRollapp_raw.(string)
+	clientIDHub := clientIDHub_raw.(string)
+
+	if clientIDRollapp == "" || clientIDHub == "" {
+		r.logger.Printf("can't find clients in the config for both rollapp and hub")
+		return false, nil
+	}
+	return true, nil
+}

--- a/relayer/clients.go
+++ b/relayer/clients.go
@@ -13,12 +13,12 @@ func (r *Relayer) CheckClientsExist() (bool, error) {
 	}
 	clientIDRollapp_raw, err := roller_utils.GetNestedValue(rlyCfg, []string{"paths", consts.DefaultRelayerPath, "dst", "client-id"})
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	clientIDHub_raw, err := roller_utils.GetNestedValue(rlyCfg, []string{"paths", consts.DefaultRelayerPath, "src", "client-id"})
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	clientIDRollapp := clientIDRollapp_raw.(string)

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -87,6 +87,8 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 
 	var src, dst string
 
+	// Sleep for a few seconds to make sure the connection is created
+	time.Sleep(15 * time.Second)
 	// we ran create channel with override, as it not recovarable anyway
 	createChannelCmd := r.getCreateChannelCmd(true)
 	status = "Creating channel..."

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -34,15 +34,7 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 	sendFundsCmd := seq.GetSendCmd(sequecerAddress)
 	utils.RunCommandEvery(ctx, sendFundsCmd.Path, sendFundsCmd.Args[1:], 20, utils.WithDiscardLogging())
 
-	//wait for block to be created
-	status := "Validating rollapp height > 2 before creating clients..."
-	fmt.Printf("💈 %s\n", status)
-	if err := r.WriteRelayerStatus(status); err != nil {
-		return ConnectionChannels{}, err
-	}
-	if err := waitForValidRollappHeight(seq); err != nil {
-		return ConnectionChannels{}, err
-	}
+	var status string
 
 	// Create client if it doesn't exist or override is true
 	clientsExist := false
@@ -54,6 +46,15 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 		}
 	}
 	if !clientsExist {
+		//wait for block to be created
+		status = "Validating rollapp height > 2 before creating clients..."
+		fmt.Printf("💈 %s\n", status)
+		if err := r.WriteRelayerStatus(status); err != nil {
+			return ConnectionChannels{}, err
+		}
+		if err := waitForValidRollappHeight(seq); err != nil {
+			return ConnectionChannels{}, err
+		}
 		// We always pass override otherwise this command hangs if there are too many clients
 		// in the hub as it iterates all to check if this client exists
 		createClientsCmd := r.getCreateClientsCmd(true)

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -24,7 +24,6 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 	// progressing for connection and channel creation.
 	// replaced update clients to avoid account sequence mismatch and
 	// premature heights updates e.g "TrustedHeight {1 x} must be less than header height {1 y}"
-	// sequecerAddress, err := utils.GetSequencerAddress(seq.RlpCfg)
 	sequecerAddress, err := utils.GetAddressBinary(utils.KeyConfig{
 		Dir: filepath.Join(seq.RlpCfg.Home, consts.ConfigDirName.Rollapp),
 		ID:  consts.KeysIds.RollappSequencer,

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -57,6 +57,10 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 		return ConnectionChannels{}, err
 	}
 
+	// Sleep for a few seconds to make sure the clients are created
+	// otherwise the connection creation fails
+	time.Sleep(10 * time.Second)
+
 	connectionID, _ := r.GetActiveConnection()
 	if connectionID == "" || override {
 		status = "Creating connection..."

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -163,7 +163,7 @@ func (r *Relayer) getCreateConnectionCmd(override bool) *exec.Cmd {
 }
 
 func (r *Relayer) getCreateChannelCmd(override bool) *exec.Cmd {
-	args := []string{"tx", "channel"}
+	args := []string{"tx", "channel", "-t", "60s", "-d"}
 	if override {
 		args = append(args, "--override")
 	}

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -20,12 +20,23 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//after successful update clients, keep running in the background
-	updateClientsCmd := r.GetUpdateClientsCmd()
-	utils.RunCommandEvery(ctx, updateClientsCmd.Path, updateClientsCmd.Args[1:], 20, utils.WithDiscardLogging())
+	// Run send funds command from sequencer to itself to make sure the chain is
+	// progressing for connection and channel creation.
+	// replaced update clients to avoid account sequence mismatch and
+	// premature heights updates e.g "TrustedHeight {1 x} must be less than header height {1 y}"
+	// sequecerAddress, err := utils.GetSequencerAddress(seq.RlpCfg)
+	sequecerAddress, err := utils.GetAddressBinary(utils.KeyConfig{
+		Dir: filepath.Join(seq.RlpCfg.Home, consts.ConfigDirName.Rollapp),
+		ID:  consts.KeysIds.RollappSequencer,
+	}, seq.RlpCfg.RollappBinary)
+	if err != nil {
+		return ConnectionChannels{}, err
+	}
+	sendFundsCmd := seq.GetSendCmd(sequecerAddress)
+	utils.RunCommandEvery(ctx, sendFundsCmd.Path, sendFundsCmd.Args[1:], 20, utils.WithDiscardLogging())
 
 	//wait for block to be created
-	status := "Waiting for state update before creating the channel..."
+	status := "Validating rollapp height on hub > 2 before creating clients..."
 	fmt.Printf("💈 %s\n", status)
 	if err := r.WriteRelayerStatus(status); err != nil {
 		return ConnectionChannels{}, err
@@ -34,15 +45,44 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 		return ConnectionChannels{}, err
 	}
 
-	var src, dst string
-	// we ran create channel with override, as it not recovarable anyway
-	createLinkCmd := r.getCreateLinkCmd(override)
-	status = "Creating link..."
+	// We always pass override otherwise this commands hangs if there are too many clients
+	// in the hub as it iterates all to check if this client exists
+	createClientsCmd := r.getCreateClientsCmd(true)
+	status = "Creating clients..."
 	fmt.Printf("💈 %s\n", status)
 	if err := r.WriteRelayerStatus(status); err != nil {
 		return ConnectionChannels{}, err
 	}
-	if err := utils.ExecBashCmd(createLinkCmd, logFileOption); err != nil {
+	if err := utils.ExecBashCmd(createClientsCmd, logFileOption); err != nil {
+		return ConnectionChannels{}, err
+	}
+
+	connectionID, _ := r.GetActiveConnection()
+	if connectionID == "" || override {
+		status = "Creating connection..."
+		fmt.Printf("💈 %s\n", status)
+		if err := r.WriteRelayerStatus(status); err != nil {
+			return ConnectionChannels{}, err
+		}
+		createConnectionCmd := r.getCreateConnectionCmd(override)
+		if err := utils.ExecBashCmd(createConnectionCmd, logFileOption); err != nil {
+			return ConnectionChannels{}, err
+		}
+	}
+
+	var src, dst string
+
+	// we ran create channel with override, as it not recovarable anyway
+	createChannelCmd := r.getCreateChannelCmd(true)
+	status = "Creating channel..."
+	fmt.Printf("💈 %s\n", status)
+	if err := r.WriteRelayerStatus(status); err != nil {
+		return ConnectionChannels{}, err
+	}
+	if err := r.WriteRelayerStatus(status); err != nil {
+		return ConnectionChannels{}, err
+	}
+	if err := utils.ExecBashCmd(createChannelCmd, logFileOption); err != nil {
 		return ConnectionChannels{}, err
 	}
 	status = "Validating channel established..."
@@ -51,7 +91,7 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 		return ConnectionChannels{}, err
 	}
 
-	src, dst, err := r.LoadActiveChannel()
+	src, dst, err = r.LoadActiveChannel()
 	if err != nil {
 		return ConnectionChannels{}, err
 	}
@@ -125,8 +165,26 @@ func waitForValidRollappHeight(seq *sequencer.Sequencer) error {
 	}
 }
 
-func (r *Relayer) getCreateLinkCmd(override bool) *exec.Cmd {
-	args := []string{"tx", "link", "-t", "300s", "--src-port", "transfer", "--dst-port", "transfer", "--version", "ics20-1"}
+func (r *Relayer) getCreateClientsCmd(override bool) *exec.Cmd {
+	args := []string{"tx", "clients"}
+	args = append(args, r.getRelayerDefaultArgs()...)
+	if override {
+		args = append(args, "--override")
+	}
+	return exec.Command(consts.Executables.Relayer, args...)
+}
+
+func (r *Relayer) getCreateConnectionCmd(override bool) *exec.Cmd {
+	args := []string{"tx", "connection", "-t", "300s", "-d"}
+	if override {
+		args = append(args, "--override")
+	}
+	args = append(args, r.getRelayerDefaultArgs()...)
+	return exec.Command(consts.Executables.Relayer, args...)
+}
+
+func (r *Relayer) getCreateChannelCmd(override bool) *exec.Cmd {
+	args := []string{"tx", "channel", "-t", "300s", "-r", "5", "-d"}
 	if override {
 		args = append(args, "--override")
 	}

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -96,9 +96,6 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 	if err := r.WriteRelayerStatus(status); err != nil {
 		return ConnectionChannels{}, err
 	}
-	if err := r.WriteRelayerStatus(status); err != nil {
-		return ConnectionChannels{}, err
-	}
 	if err := utils.ExecBashCmd(createChannelCmd, logFileOption); err != nil {
 		return ConnectionChannels{}, err
 	}
@@ -160,7 +157,7 @@ func (r *Relayer) getCreateClientsCmd(override bool) *exec.Cmd {
 }
 
 func (r *Relayer) getCreateConnectionCmd(override bool) *exec.Cmd {
-	args := []string{"tx", "connection", "-t", "300s", "-d"}
+	args := []string{"tx", "connection"}
 	if override {
 		args = append(args, "--override")
 	}
@@ -169,7 +166,7 @@ func (r *Relayer) getCreateConnectionCmd(override bool) *exec.Cmd {
 }
 
 func (r *Relayer) getCreateChannelCmd(override bool) *exec.Cmd {
-	args := []string{"tx", "channel", "-t", "300s", "-r", "5", "-d"}
+	args := []string{"tx", "channel"}
 	if override {
 		args = append(args, "--override")
 	}

--- a/relayer/create_ibc_channel.go
+++ b/relayer/create_ibc_channel.go
@@ -32,7 +32,7 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 		return ConnectionChannels{}, err
 	}
 	sendFundsCmd := seq.GetSendCmd(sequecerAddress)
-	utils.RunCommandEvery(ctx, sendFundsCmd.Path, sendFundsCmd.Args[1:], 20, utils.WithDiscardLogging())
+	utils.RunCommandEvery(ctx, sendFundsCmd.Path, sendFundsCmd.Args[1:], 5, utils.WithDiscardLogging())
 
 	var status string
 
@@ -40,10 +40,7 @@ func (r *Relayer) CreateIBCChannel(override bool, logFileOption utils.CommandOpt
 	clientsExist := false
 	if !override {
 		// Check if clients exist
-		clientsExist, err = r.CheckClientsExist()
-		if err != nil {
-			return ConnectionChannels{}, err
-		}
+		clientsExist, _ = r.CheckClientsExist()
 	}
 	if !clientsExist {
 		//wait for block to be created

--- a/sequencer/commands.go
+++ b/sequencer/commands.go
@@ -18,7 +18,6 @@ func (seq *Sequencer) GetSendCmd(destAddress string) *exec.Cmd {
 		"--broadcast-mode", "block",
 		"--keyring-backend", "test",
 		"--yes",
-		"--log-file", filepath.Join(rollappConfigDir, "rollapp.log"),
 	)
 	return cmd
 }

--- a/sequencer/commands.go
+++ b/sequencer/commands.go
@@ -1,0 +1,24 @@
+package sequencer
+
+import (
+	"os/exec"
+	"path/filepath"
+
+	"github.com/dymensionxyz/roller/cmd/consts"
+)
+
+// TODO(FIXME): Assumptions on rollapp price and keyring backend
+func (seq *Sequencer) GetSendCmd(destAddress string) *exec.Cmd {
+	rollappConfigDir := filepath.Join(seq.RlpCfg.Home, consts.ConfigDirName.Rollapp)
+	cmd := exec.Command(
+		seq.RlpCfg.RollappBinary,
+		"tx", "bank", "send",
+		consts.KeysIds.RollappSequencer, destAddress, "1"+seq.RlpCfg.Denom,
+		"--home", rollappConfigDir,
+		"--broadcast-mode", "block",
+		"--keyring-backend", "test",
+		"--yes",
+		"--log-file", filepath.Join(rollappConfigDir, "rollapp.log"),
+	)
+	return cmd
+}


### PR DESCRIPTION
This PR improves substantially the channel creation.
Channel creation is now done < 3 mins. 

It removes unnecessary code which used the old assumption of the forked ibc and changed the chain block production to use send fund commands from sequencer to itself vs update-client which would introduce problems such as account sequence mismatch and header heights coordination between received ibc packet header and already existing ibc header sent using the update command. 

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [x]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
