### PR TITLE
chore: Add install binaries instruction to Readme testing section

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,50 +28,11 @@ jobs:
         run: |
           make build
           sudo cp ./build/roller /usr/local/bin/roller
-      - name: Get the latest version of Celestia Node
-        run: |
-          if [ -d "./celestia-node" ]; then
-            cd celestia-node
-            git fetch --all
-          else
-            git clone https://github.com/celestiaorg/celestia-node.git
-            cd celestia-node
-          fi
-          git checkout tags/v0.11.0-rc6.1
-      - name: Set up Go 1.20
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-      - name: Build Celestia Node
-        run: |
-          cd ./celestia-node
-          make build
-          make go-install
-          make cel-key
-      - name: Get the latest version of the cosmos sdk
-        run: |
-          if [ -d "./cosmos-sdk" ]; then
-            cd cosmos-sdk
-            git fetch --all
-          else
-            git clone https://github.com/cosmos/cosmos-sdk.git
-            cd cosmos-sdk
-          fi
-          git checkout tags/v0.47.5
-      - name: Build cosmos-sdk
-        run: |
-          cd ./cosmos-sdk
-          make build
       - name: Create roller_bins archive folder structure
         run: |
           rm -rf roller_bins
           mkdir roller_bins
           mkdir roller_bins/lib
-          sudo cp ./celestia-node/cel-key ./roller_bins/lib/cel-key
-          sudo cp ./celestia-node/cel-key /usr/local/bin/roller_bins/cel-key
-          sudo cp ./celestia-node/build/celestia ./roller_bins/lib/celestia
-          sudo cp ./celestia-node/build/celestia /usr/local/bin/roller_bins/celestia
-          sudo cp ./cosmos-sdk/build/simd ./roller_bins/lib/simd
           sudo cp -r /usr/local/bin/roller_bins/* ./roller_bins/lib/
           sudo cp /usr/local/bin/roller ./roller_bins/roller
           sudo cp /usr/local/bin/rollapp_evm ./roller_bins/rollapp_evm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Create Roller Release Assets
 on:
   release:
     types: [ created ]
+  push:
+    branches:
+      - itaylevyofficial/615-fix-tests
 
 jobs:
   build:
@@ -18,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Run the roller installation script
         run: |
           [ -f ~/.zshrc ] && source ~/.zshrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Create Roller Release Assets
 on:
   release:
     types: [ created ]
+  push:
+    branches:
+      - itaylevyofficial/615-fix-tests
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.20.x
       - name: Run the roller installation script
         run: |
           [ -f ~/.zshrc ] && source ~/.zshrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ name: Create Roller Release Assets
 on:
   release:
     types: [ created ]
-  push:
-    branches:
-      - itaylevyofficial/615-fix-tests
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ To run Roller, use:
 
 ## Testing
 
-First, make sure you have the latest version of all the dependencies:
+First, make sure you have the latest version of all the dependencies by running the compile locally script:
 
 ```bash
-curl -L https://dymensionxyz.github.io/roller/install.sh | bash
+yes | ./compile_locally.sh
 ```
 
 To run the all the tests, run from the root directory:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ To run Roller, use:
 
 ## Testing
 
-First, make sure you have the latest version of all the dependencies by
-running the compile locally script:
+First, ensure that the versions of all dependencies match the code 
+by running the local compilation script:
 
 ```bash
 yes | ./compile_locally.sh

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ To run Roller, use:
 
 ## Testing
 
-First, ensure that the versions of all dependencies match the code 
-by running the local compilation script:
+First, ensure that the versions of all dependencies match the code
+ by running the local compilation script:
 
 ```bash
 yes | ./compile_locally.sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ To run Roller, use:
 
 ## Testing
 
+First, make sure you have the latest version of all the dependencies:
+
+```bash
+curl -L https://dymensionxyz.github.io/roller/install.sh | bash
+```
+
 To run the all the tests, run from the root directory:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ To run Roller, use:
 
 ## Testing
 
-First, make sure you have the latest version of all the dependencies by running the compile locally script:
+First, make sure you have the latest version of all the dependencies by
+running the compile locally script:
 
 ```bash
 yes | ./compile_locally.sh

--- a/compile_locally.sh
+++ b/compile_locally.sh
@@ -68,12 +68,10 @@ fi
 for i in "${!PROJECTS[@]}"; do
     echo "$EMOJI handling ${PROJECTS[i]}..."
     cd /tmp
-    echo ${BINARYNAME[i]}
     for binary in ${BINARYNAME[i]}; do
         echo "$EMOJI checking for $binary..."
         if [ -x "$(command -v "$binary")" ]; then
             read -p "$binary already exists. Do you want to overwrite it? (y/n) " -n 1 -r
-            echo
             if [[ $REPLY =~ ^[Nn]$ ]]; then
                 binary_path=$(which "$binary" 2> /dev/null)  # Redirect error output to /dev/null
                 sudo cp "$binary_path" "$INTERNAL_DIR"

--- a/compile_locally.sh
+++ b/compile_locally.sh
@@ -72,6 +72,7 @@ for i in "${!PROJECTS[@]}"; do
         echo "$EMOJI checking for $binary..."
         if [ -x "$(command -v "$binary")" ]; then
             read -p "$binary already exists. Do you want to overwrite it? (y/n) " -n 1 -r
+            echo
             if [[ $REPLY =~ ^[Nn]$ ]]; then
                 binary_path=$(which "$binary" 2> /dev/null)  # Redirect error output to /dev/null
                 sudo cp "$binary_path" "$INTERNAL_DIR"

--- a/compile_locally.sh
+++ b/compile_locally.sh
@@ -40,7 +40,7 @@ sudo mkdir -p "$INTERNAL_DIR"
 sudo mkdir -p "/tmp/roller_tmp"
 
 # Function to display Go installation instructions
-GO_REQUIRED_VERSION="1.19"
+GO_REQUIRED_VERSION="1.20"
 display_go_installation_instructions() {
     echo "$EMOJI To install Go $GO_REQUIRED_VERSION, you can run the following commands:"
     echo "  wget https://go.dev/dl/go1.19.10.${OS}-${ARCH}.tar.gz"

--- a/compile_locally.sh
+++ b/compile_locally.sh
@@ -11,11 +11,11 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 # The list of projects to be installed
-PROJECTS=("dymension" "go-relayer" "rollapp-evm", "celestia-node")
-REPOS=("" "" "" "https://github.com/celestiaorg/celestia-node")
-VERSIONS=("v2.0.0-alpha.3" "v0.2.0-v2.3.1-relayer" "v1.0.1-beta", "v0.11.0-rc6.1")
+PROJECTS=("dymension" "go-relayer" "rollapp-evm" "celestia-node" "cosmos-sdk")
+REPOS=("" "" "" "https://github.com/celestiaorg/celestia-node" "https://github.com/cosmos/cosmos-sdk.git")
+VERSIONS=("v2.0.0-alpha.3" "v0.2.0-v2.3.1-relayer" "v1.0.1-beta" "v0.11.0-rc6.1" "v0.47.5")
 BUILDCOMMANDS=("" "" "" "make go-install install-key")
-BINARYNAME=("dymd" "rly" "rollapp-evm" "celestia cel-key")
+BINARYNAME=("dymd" "rly" "rollapp-evm" "celestia cel-key" "simd")
 
 if [[ "$ARCH" == "x86_64" ]]; then
     ARCH="amd64"
@@ -68,22 +68,23 @@ fi
 for i in "${!PROJECTS[@]}"; do
     echo "$EMOJI handling ${PROJECTS[i]}..."
     cd /tmp
-
-    # Check if binaries already exist
-    IFS=' ' read -r -a binary_array <<< "${BINARYNAME[i]}"  # convert string to array
-    binary=${binary_array[0]}  # get the first element
-    echo "$EMOJI checking for $binary..."
-    if [ -x "$(command -v "$binary")" ]; then
-        read -p "$binary already exists. Do you want to overwrite it? (y/n) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then
-            binary_path=$(which "$binary" 2> /dev/null)  # Redirect error output to /dev/null
-            sudo cp "$binary_path" "$INTERNAL_DIR"
-            continue 1
-        else
-            rm -f "$binary_path"
+    echo ${BINARYNAME[i]}
+    for binary in ${BINARYNAME[i]}; do
+        echo "$EMOJI checking for $binary..."
+        if [ -x "$(command -v "$binary")" ]; then
+            read -p "$binary already exists. Do you want to overwrite it? (y/n) " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                binary_path=$(which "$binary" 2> /dev/null)  # Redirect error output to /dev/null
+                sudo cp "$binary_path" "$INTERNAL_DIR"
+                if [ "$binary" != "celestia" ]; then
+                  continue 2
+                fi
+            else
+                rm -f "$binary_path"
+            fi
         fi
-    fi
+    done
 
     REPO_URL=${REPOS[i]:-"https://github.com/dymensionxyz/${PROJECTS[i]}"}
     rm -rf "/tmp/${PROJECTS[i]}"

--- a/compile_locally.sh
+++ b/compile_locally.sh
@@ -11,11 +11,11 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 # The list of projects to be installed
-PROJECTS=("dymension" "go-relayer" "rollapp-evm")
-REPOS=("" "" "")
-VERSIONS=("v2.0.0-alpha.3" "v0.2.0-v2.3.1-relayer" "v1.0.1-beta")
-BUILDCOMMANDS=("" "" "")
-BINARYNAME=("dymd" "rly" "rollapp-evm")
+PROJECTS=("dymension" "go-relayer" "rollapp-evm", "celestia-node")
+REPOS=("" "" "" "https://github.com/celestiaorg/celestia-node")
+VERSIONS=("v2.0.0-alpha.3" "v0.2.0-v2.3.1-relayer" "v1.0.1-beta", "v0.11.0-rc6.1")
+BUILDCOMMANDS=("" "" "" "make go-install install-key")
+BINARYNAME=("dymd" "rly" "rollapp-evm" "celestia cel-key")
 
 if [[ "$ARCH" == "x86_64" ]]; then
     ARCH="amd64"
@@ -87,11 +87,8 @@ for i in "${!PROJECTS[@]}"; do
 
     REPO_URL=${REPOS[i]:-"https://github.com/dymensionxyz/${PROJECTS[i]}"}
     rm -rf "/tmp/${PROJECTS[i]}"
-    git clone "$REPO_URL"
+    git clone "$REPO_URL" --branch "${VERSIONS[i]}" --depth 1
     cd "${PROJECTS[i]}"
-    if [ -n "${VERSIONS[i]}" ]; then
-        git checkout "${VERSIONS[i]}"
-    fi
     if [ -n "${BUILDCOMMANDS[i]}" ]; then
         ${BUILDCOMMANDS[i]}
     else
@@ -102,7 +99,7 @@ for i in "${!PROJECTS[@]}"; do
         if [ ! -x "$(command -v "$binary")" ]; then
             echo "$EMOJI Couldn't find $binary in PATH. Aborting."; exit 1;
         fi
-        binary_path=$(which "$binary" 2> /dev/null)  # Redirect error output to /dev/null
+        binary_path=$(which "$binary" 2> /dev/null)
         sudo cp "$binary_path" "$INTERNAL_DIR"
     done
 done


### PR DESCRIPTION
Moved the compilation of the Celestia & Cosmos SDK binaries to the compile_locally script for it to create a working roller version upon completion, and added instruction in the README file to run it before running the tests. They was separated initially because dymint didn't compile with go1.20, but it has already been addressed in the used version.

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [x]  Targeted PR against correct branch
- [x]  Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to Github issue with discussion and accepted design
- [x]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case PR targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
