### PR TITLE
chore(readme):Fix broken/outdated Roller CLI documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ export ROLLER_RELEASE_TAG="<RELEASE_TAG>"
 curl -L https://dymensionxyz.github.io/roller/install.sh | bash
 ```
 
-For more information about Roller and its usage, please refer to [the documentation](https://docs.dymension.xyz/build/roller).
+For more information about Roller and its usage, please refer to [the documentation](https://docs.dymension.xyz/build/roller/overview).


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---
The link to the Roller CLI documentation in the readme was broken. This PR updates it to point to the correct documentation URL (https://docs.dymension.xyz/build/roller/overview). This ensures users have access to the relevant information.

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case PR targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
