### PR TITLE
fix: add `extra-codecs` to relayer config root

### DIFF
--- a/cmd/relayer/setup/setup.go
+++ b/cmd/relayer/setup/setup.go
@@ -229,6 +229,9 @@ func Cmd() *cobra.Command {
 						rollerData.HubData.ID,
 					): rollerData.HubData.API_URL,
 					fmt.Sprintf("chains.%s.value.is-dym-rollapp", rollerData.RollappID): true,
+					"extra-codecs": []string{
+						"ethermint",
+					},
 				}
 				err = yamlconfig.UpdateNestedYAML(relayerConfigPath, updates)
 				if err != nil {


### PR DESCRIPTION
this will add `extra-codecs` to the root of the relayer config

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case PR targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
