### PR TITLE
fix: update dependency retrieval to support different ra types

### DIFF
--- a/cmd/relayer/setup/setup.go
+++ b/cmd/relayer/setup/setup.go
@@ -306,9 +306,17 @@ func installRelayerDependencies(
 		return err
 	}
 
+	var raCommit string
+	switch strings.ToLower(raResp.Rollapp.VmType) {
+	case "evm":
+		raCommit = drsInfo.EvmCommit
+	case "wasm":
+		raCommit = drsInfo.WasmCommit
+	}
+
 	rbi := dependencies.NewRollappBinaryInfo(
 		raResp.Rollapp.GenesisInfo.Bech32Prefix,
-		drsInfo.Commit,
+		raCommit,
 		strings.ToLower(raResp.Rollapp.VmType),
 	)
 

--- a/utils/dependencies/rollapp.go
+++ b/utils/dependencies/rollapp.go
@@ -58,18 +58,19 @@ func DefaultRollappDependency(raBinInfo RollappBinaryInfo) types.Dependency {
 		}
 	case "wasm":
 		dep = types.Dependency{
-			DependencyName:  "dymd",
+			DependencyName:  "rollapp",
 			RepositoryOwner: "dymensionxyz",
-			RepositoryName:  "dymd",
-			RepositoryUrl:   "https://github.com/dymensionxyz/dymd.git",
-			Release:         DefaultDymdDependency().Release,
+			RepositoryName:  "rollapp-wasm",
+			RepositoryUrl:   "https://github.com/dymensionxyz/rollapp-wasm.git",
+			Release:         raBinInfo.Commit,
 			Binaries: []types.BinaryPathPair{
 				{
-					Binary:            "./build/dymd",
-					BinaryDestination: consts.Executables.Dymension,
+					Binary:            "./build/rollapp-wasm",
+					BinaryDestination: consts.Executables.RollappEVM,
 					BuildCommand: exec.Command(
 						"make",
 						"build",
+						fmt.Sprintf("BECH32_PREFIX=%s", raBinInfo.Bech32Prefix),
 					),
 				},
 			},

--- a/utils/firebase/firebase.go
+++ b/utils/firebase/firebase.go
@@ -6,14 +6,15 @@ import (
 
 	"cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go"
-	"github.com/pterm/pterm"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
 // DrsVersionInfo represents the structure of DRS version information in Firestore
 type DrsVersionInfo struct {
-	Commit string `firestore:"commit"`
+	Commit     string `firestore:"commit"`
+	EvmCommit  string `firestore:"evm-commit"`
+	WasmCommit string `firestore:"wasm-commit"`
 }
 
 // GetLatestDrsVersionCommit
@@ -55,6 +56,5 @@ func GetLatestDrsVersionCommit(drsVersion string) (*DrsVersionInfo, error) {
 		return nil, fmt.Errorf("failed to parse DRS version info: %v", err)
 	}
 
-	pterm.Info.Printf("Found DRS commit hash: %s\n", drsInfo.Commit)
 	return &drsInfo, nil
 }


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case PR targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
