### PR TITLE
Typo fix dependencies.go

### DIFF
--- a/utils/dependencies/dependencies.go
+++ b/utils/dependencies/dependencies.go
@@ -49,7 +49,7 @@ func InstallBinaries(withMockDA bool, raResp rollapp.ShowRollappResponse) (
 	var drsVersion string
 	raVmType := strings.ToLower(raResp.Rollapp.VmType)
 	if !withMockDA {
-		// TODO refactor, this genesis file fetch is redundand and will slow the process down
+		// TODO refactor, this genesis file fetch is redundant and will slow the process down
 		// when the genesis file is big
 		err = genesisutils.DownloadGenesis(genesisTmpDir, raResp.Rollapp.Metadata.GenesisUrl)
 		if err != nil {


### PR DESCRIPTION
# **Fix Typo in `dependencies.go`**

## **Description**
This pull request fixes a minor typo in the `dependencies.go` file. The word **"redundand"** was corrected to **"redundant"** to improve clarity and maintain code readability.

## **Changes**
- Corrected typo in the following comment:
  - **Before:** `// TODO refactor, this genesis file fetch is redundand and will slow the process down`
  - **After:** `// TODO refactor, this genesis file fetch is redundant and will slow the process down`
