### PR TITLE
fix: use different validator endpoint for non-mainnet envs

### DIFF
--- a/utils/genesis/genesis.go
+++ b/utils/genesis/genesis.go
@@ -407,7 +407,8 @@ type ValidateGenesisRequest struct {
 }
 
 const (
-	ValidateGenesisURL = "https://genesis-validator.rollapp.network/validate-genesis"
+	MainnetValidateGenesisURL = "https://genesis-validator.rollapp.network/validate-genesis"
+	TestnetValidateGenesisURL = "https://next.genesis-validator.rollapp.network/validate-genesis"
 )
 
 func ValidateGenesis(raCfg roller.RollappConfig, raID string, hd consts.HubData) error {
@@ -436,7 +437,15 @@ func ValidateGenesis(raCfg roller.RollappConfig, raID string, hd consts.HubData)
 		return err
 	}
 
-	resp, err := http.Post(ValidateGenesisURL, "application/json", bytes.NewBuffer(b))
+	var ValidateGenesisUrl string
+	if hd.ID == consts.MainnetHubID {
+		ValidateGenesisUrl = MainnetValidateGenesisURL
+	} else {
+		ValidateGenesisUrl = TestnetValidateGenesisURL
+	}
+
+	// nolint gosec
+	resp, err := http.Post(ValidateGenesisUrl, "application/json", bytes.NewBuffer(b))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case PR targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
