### PR TITLE
feat: add flags to setup node

### DIFF
--- a/cmd/rollapp/init/utils.go
+++ b/cmd/rollapp/init/utils.go
@@ -18,6 +18,7 @@ func runInit(
 	hubData consts.HubData,
 	raResp rollapp.ShowRollappResponse,
 	kb consts.SupportedKeyringBackend,
+	shouldGenerateSequencerAddress bool,
 ) error {
 	raID := raResp.Rollapp.RollappId
 
@@ -54,7 +55,7 @@ func runInit(
 	/* ------------------------------ Generate keys ----------------------------- */
 	var addresses []keys.KeyInfo
 
-	sequencerKeys, err := initSequencerKeys(home, env, ic)
+	sequencerKeys, err := initSequencerKeys(home, env, ic, shouldGenerateSequencerAddress)
 	if err != nil {
 		return err
 	}
@@ -175,12 +176,17 @@ func runInit(
 	return nil
 }
 
-func initSequencerKeys(home string, env string, ic roller.RollappConfig) ([]keys.KeyInfo, error) {
+func initSequencerKeys(
+	home string,
+	env string,
+	ic roller.RollappConfig,
+	shouldGenerateSequencerAddress bool,
+) ([]keys.KeyInfo, error) {
 	err := keys.CreateSequencerOsKeyringPswFile(home)
 	if err != nil {
 		return nil, err
 	}
-	sequencerKeys, err := keys.GenerateSequencerKeys(home, env, ic)
+	sequencerKeys, err := keys.GenerateSequencerKeys(home, env, ic, shouldGenerateSequencerAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rollapp/setup/setup.go
+++ b/cmd/rollapp/setup/setup.go
@@ -1078,8 +1078,13 @@ func getDaLayer(home string, raResponse *rollapp.ShowRollappResponse, daType con
 	}
 }
 
-func getDaConfig(dataLayer datalayer.DataLayer, nodeType string, home string, raResponse *rollapp.ShowRollappResponse, rollappConfig *roller.RollappConfig) any {
-
+func getDaConfig(
+	dataLayer datalayer.DataLayer,
+	nodeType string,
+	home string,
+	raResponse *rollapp.ShowRollappResponse,
+	rollappConfig *roller.RollappConfig,
+) any {
 	daConfig := dataLayer.GetSequencerDAConfig(consts.NodeType.Sequencer)
 
 	drsVersion, err := genesis.GetDrsVersionFromGenesis(home, raResponse)

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -34,7 +34,7 @@ func DirNotEmpty(path string) (bool, error) {
 	return len(files) > 0, err
 }
 
-func CreateRollerRootWithOptionalOverride(home string) error {
+func CreateRollerRootWithOptionalOverride(home string, forceOverwrite bool) error {
 	isRootExist, err := DirNotEmpty(home)
 	if err != nil {
 		return err
@@ -43,14 +43,17 @@ func CreateRollerRootWithOptionalOverride(home string) error {
 	if isRootExist {
 		fmt.Printf("Directory %s is not empty.\n", home)
 
-		shouldOverwrite, err := pterm.DefaultInteractiveConfirm.WithDefaultText(fmt.Sprintf("Do you want to overwrite %s?", home)).
-			WithDefaultValue(false).
-			Show()
-		if err != nil {
-			return err
+		var shouldOverwrite bool
+		if !forceOverwrite {
+			shouldOverwrite, err = pterm.DefaultInteractiveConfirm.WithDefaultText(fmt.Sprintf("Do you want to overwrite %s?", home)).
+				WithDefaultValue(false).
+				Show()
+			if err != nil {
+				return err
+			}
 		}
 
-		if shouldOverwrite {
+		if shouldOverwrite || forceOverwrite {
 			err = os.RemoveAll(home)
 			if err != nil {
 				return err

--- a/utils/keys/sequencer.go
+++ b/utils/keys/sequencer.go
@@ -45,7 +45,11 @@ func CreateDaOsKeyringPswFile(home string) error {
 	return config.WritePasswordToFile(daFp)
 }
 
-func GenerateSequencerKeys(home, env string, rollerData roller.RollappConfig) ([]KeyInfo, error) {
+func GenerateSequencerKeys(
+	home, env string,
+	rollerData roller.RollappConfig,
+	shouldGenerateSequencerAddress bool,
+) ([]KeyInfo, error) {
 	var k []KeyInfo
 	var err error
 
@@ -55,7 +59,7 @@ func GenerateSequencerKeys(home, env string, rollerData roller.RollappConfig) ([
 			return nil, err
 		}
 	} else {
-		k, err = generateRaSequencerKeys(home, rollerData)
+		k, err = generateRaSequencerKeys(home, rollerData, shouldGenerateSequencerAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -86,10 +90,17 @@ func generateMockSequencerKeys(initConfig roller.RollappConfig) ([]KeyInfo, erro
 	return addresses, nil
 }
 
-func generateRaSequencerKeys(home string, rollerData roller.RollappConfig) ([]KeyInfo, error) {
-	useExistingSequencerWallet, _ := pterm.DefaultInteractiveConfirm.WithDefaultText(
-		"would you like to import an existing sequencer key?",
-	).Show()
+func generateRaSequencerKeys(
+	home string,
+	rollerData roller.RollappConfig,
+	shouldGenerateSequencerAddress bool,
+) ([]KeyInfo, error) {
+	var useExistingSequencerWallet bool
+	if !shouldGenerateSequencerAddress {
+		useExistingSequencerWallet, _ = pterm.DefaultInteractiveConfirm.WithDefaultText(
+			"would you like to import an existing sequencer key?",
+		).Show()
+	}
 
 	var addr []KeyInfo
 	var err error


### PR DESCRIPTION
this PR enables setting up the rollapp node using flags rather then going through the wizard, eg:

```
roller rollapp init teamartevm_479441-1 --generate-sequencer-address --env blumbus --overwrite
```

and

```
roller rollapp setup --node-type fullnode --full-node-type rpc
```